### PR TITLE
Allow config.relativeUrl for issue #14

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -16,7 +16,7 @@ var api = {
             files = fs.readdirSync(dxPath),
             front = 'Ext.ns("' + config.namespace +'");' + config.namespace + '.' + config.apiName + '=',
             res  = {
-                "url": config.protocol + '://' + config.server + (config.port == '80' ? '' : (':'+ config.port))+  config.classPath,
+                "url": config.relativeUrl ? config.classPath : config.protocol + '://' + config.server + (config.port == '80' ? '' : (':'+ config.port))+  config.classPath,
                 "namespace" : config.namespace,
                 "type": "remoting",
                 "actions": {}


### PR DESCRIPTION
Have tested this to work.  If now I add

```
"relativeUrl": true,
```

to the ExtDirectConfig then it produces "url": "/myapi" and then it works for any server and network configuration we have, where the server address is wildly varying but always the same as the webpage.
