### PR TITLE
Add option for standard node callback convention (err, result)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -91,6 +91,49 @@ var route = {
                 }
             }.apply(null, [so]);
 
+            if(config.conventionalCallbackFormat) {
+                callback = function(so){
+                    return function(err, result){
+                        var packet;                        
+                        if(err !== null){
+                            packet = {
+                                type: 'exception',
+                                tid: so.tid,
+                                action: so.action,
+                                method: so.method,
+                                message: '',
+                                data: null
+                            };
+
+                            if(process.env.NODE_ENV !== 'production'){
+                                packet.message = err.message;
+                                packet.data = err;
+                            }
+                        }else{
+                            packet = {
+                                type: result.event ? 'event' : 'rpc',
+                                tid: so.tid,
+                                action: so.action,
+                                method: so.method,
+                                result: result
+                            };
+
+                            if(result.event){
+                                packet.data = event;
+                                delete result.event;
+                            }
+                            
+                            if(config.autoSetSuccess){
+                                packet.success = true;
+                            }
+                        }
+                        batch.push(packet);
+                        reduce--;
+                        finalCallback(batch);
+                    }
+                }.apply(null, [so]);
+            }
+            
             x = require(vPath.join(root, config.classPath, so.action));
 
             if(!so.data){


### PR DESCRIPTION
This pull request is more to show my point, maybe you did not implement it this way for a reason.

I see that you have a way to intentionally send back exceptions:
```javascript
if(err){
    callback(null, 'exception', err);
}else{
    callback({
        success: true,
        data: rows,
        total: rowsTotal[0].totals
    });
}
```

But this is not really in line with the standard node callback(err, results) convention. Why not do:
```javascript
if(err){
    callback(err);
}else{
    callback(null, {
        data: rows,
        total: rowsTotal[0].totals
    });
}
```

This way you might be able to pass the callback to a lot of standard functions directly.
And maybe even automatically set success:true if error is null?

To use this, do:
```javascript
var directCfg = {
    namespace: "ExtRemote",
    apiName: "REMOTING_API",
    apiPath: "/directapi",
    classPath: "/direct",
    classPrefix: "DX",
    relativeUrl: true,
    appendRequestResponseObjects: true,
    conventionalCallbackFormat: true,
    autoSetSuccess: true
};

// Now you can do:
// [...]
read: function(params, callback, sessionID, request, response) {
    models.Foo.findAll({raw: true}).complete(callback);
}
// Instead off
read: function(params, callback, sessionID, request, response) {
    models.Foo.findAll({raw: true}).complete(function(err,results) {
        callback(results);
    });
}
// [...]
```