### PR TITLE
Rudimentry policy enforcement. - Ready for discussion but not merging

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -1,5 +1,7 @@
 var vPath = require('path');
-
+var escapeRegExp = function(string){
+    return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
+};
 var route = {
     processRoute : function(req, resp, config){
         var root = __dirname.replace(vPath.normalize('/node_modules/extdirect/lib'),''),
@@ -14,6 +16,28 @@ var route = {
             batch = [],
             x,
             i;
+
+        var processMetadata = false;
+        if (config.PolicyClass) {
+            var Policy = require(vPath.join(root, config.classPath, config.PolicyClass));
+            processMetadata = function(fnString) {
+                var metadata = config.metaDefaults ? route.copyObject(config.metaDefaults) : {};
+                var metadataRE = new RegExp(escapeRegExp(config.classPrefix) + '\\:(\\w*)\\:(\\w*)', 'g');
+                var match;
+
+                while (match = metadataRE.exec(fnString)) {
+                    var key = match[1],
+                        value = match[2];
+                    if (value === 'true') {
+                        value = true;
+                    } else if (value === 'false') {
+                        value = false;
+                    }
+                    metadata[key] = value;
+                }
+                return Policy.isAccepted(metadata, req);
+            };
+        }
 
         //process after we return from DX method
         var finalCallback = function(batch){
@@ -117,7 +141,11 @@ var route = {
             }
 
             try{
-                x[so.method].apply({},so.data);
+                if (!processMetadata || processMetadata(x[so.method].toString()) !== false) {
+                    x[so.method].apply({},so.data);    
+                } else {
+                    callback({success: false, auth: 'Authorization failed.'});
+                }
             }catch(e) {
                 if(process.env.NODE_ENV !== 'production'){
                     batch.push({


### PR DESCRIPTION
@jurisv This is a rough implementation of the discussion we were having last week about policy enforcement and securing methods that are exposed at the service layer.

It's ready for discussion but certainly not merging.

The basic idea is the ability to put strings in your methods that match the pattern
{classPrefix}:{key}:{value}

Before executing the method, we parse it gather this metadata and then pass it to a Policy class. The policy Class is configured by passing in PolicyClass (will fix case to be policyClass). This PolicyClass implements an isAccepted method and is passed the metadata and the request object (so it can read things like session variables).

This information could certainly be built and cached when we generate the api and re-used.

It solves the problem of execution of methods that should not return any data but it does not solve the problem of having those methods in the API stub itself. Problem is it's not just as simple as saying x,y,z methods belong to this group and a,b,c methods belong to this other group. Execution can be very contextual, ie did the user already complete this step or the next one, etc

Thoughts?
