### PR TITLE
Fixed issue when returning boolean false

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -124,7 +124,7 @@ function Router(config) {
 
                 return function(error, result) {
                     var newPacket;
-                    result = result || {};
+                    result = result !== undefined ? result : {};
 
                     if(error) {
                         newPacket = {


### PR DESCRIPTION
When returning the boolean false value from a server api method, the router is substituting a default object instead (looks like it was looking for an undefined value, but the value false will trigger this substitution).  I think there are cases where the false value should be returned to the client, so this change will fix that.