### PR TITLE
replace all '.' w/ '/' for deeper routed modules

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -177,7 +177,7 @@ function Router(config) {
                 }
             }.apply(null, [currentPacket]);
 
-            apiPath = vPath.join(root, config.classPath, currentPacket.action.replace('.', slash)) + '.js';
+            apiPath = vPath.join(root, config.classPath, currentPacket.action.split('.').join(slash) ) + '.js';
             api = require(apiPath);
 
             if(!config.cacheAPI){


### PR DESCRIPTION
The current replace method only supports one level deep replace resulting in errors in routing to deeper .js file paths. This change allows deeply nested modules to work correctly. It also avoids complex regEx replaces.